### PR TITLE
feat(openai): expose Responses API response id as vendor_id

### DIFF
--- a/pydantic_ai_slim/pydantic_ai/models/openai.py
+++ b/pydantic_ai_slim/pydantic_ai/models/openai.py
@@ -599,7 +599,7 @@ class OpenAIResponsesModel(Model):
         for item in response.output:
             if item.type == 'function_call':
                 items.append(ToolCallPart(item.name, item.arguments, tool_call_id=item.call_id))
-        return ModelResponse(items, usage=_map_usage(response), model_name=response.model, timestamp=timestamp)
+        return ModelResponse(items, usage=_map_usage(response), model_name=response.model, timestamp=timestamp, vendor_id=response.id)
 
     async def _process_streamed_response(
         self, response: AsyncStream[responses.ResponseStreamEvent]


### PR DESCRIPTION
OpenAIResponsesModel now sets

vendor_id = response.id